### PR TITLE
Add Express backend and API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# OBE
+# Outcome Based Education (OBE) Management Portal
+
+This repository contains a lightweight single-page web application for planning and tracking Outcome Based Education (OBE) workflows. A companion Node.js/Express backend exposes REST endpoints and persists information to a JSON data store, providing a simple self-hosted deployment path.
+
+## Features
+
+The portal covers the typical artefacts required to manage OBE processes:
+
+- **Basic setups** – capture programs and semesters.
+- **Course entry** – register courses with program, semester and credit information.
+- **Student entry** – maintain basic student records and the program they belong to.
+- **Enrolment entry** – enrol students into courses for a given semester and academic year.
+- **Program outcome setup** – define POs for each academic program.
+- **Course outcome setup** – define COs for each course.
+- **CO–PO mapping** – align course outcomes with program outcomes and assign contribution weights.
+- **Assessment setup** – create assessment components for courses.
+- **Assessment–CO mapping** – connect assessments with the course outcomes they measure.
+- **Mark uploading** – record assessment marks per student enrolment.
+- **Mark view** – view marks per assessment for all students in a course.
+- **CO achievement reports** – generate course outcome attainment for an individual student or aggregated by semester.
+- **PO achievement reports** – generate program outcome attainment for individual students or aggregated by semester.
+- **PO–CO mapping report** – visualise the alignment matrix for a program.
+- **Course CQI reports** – capture continuous quality improvement summaries and actions per course.
+
+## Getting started
+
+1. Clone or download the repository.
+2. Install dependencies: `npm install`.
+3. Start the backend (which also serves the frontend assets): `npm start`.
+4. Navigate to [http://localhost:3000](http://localhost:3000) in a modern browser (Chrome, Edge, Firefox or Safari).
+
+All application data is stored in `data.json` on the server. Stop the server before editing the file manually.
+
+## Technology stack
+
+- Plain HTML, CSS and JavaScript (no client-side frameworks required).
+- Tailored styling with CSS, including responsive layouts for smaller screens.
+- Node.js with Express for the API and static asset hosting.
+- File-based JSON persistence (`data.json`).
+
+## Development notes
+
+- The application is intentionally framework-free on the client to allow quick prototyping in constrained environments, while the backend is kept minimal for ease of hosting.
+- Frontend logic lives in `app.js`. API routes are implemented in `server.js`, which writes to `data.json` for persistence.
+- Styles are defined in `styles.css` and follow a modern dashboard aesthetic.
+
+## Disclaimer
+
+This project focuses on core data capture and reporting flows for OBE management. It does not include authentication, role management, or integrations with institutional systems. Always evaluate data governance needs before using with real student information.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,1185 @@
+const API_BASE = '/api';
+
+const initialData = {
+    programs: [],
+    semesters: [],
+    courses: [],
+    students: [],
+    enrolments: [],
+    programOutcomes: [],
+    courseOutcomes: [],
+    coPoMappings: [],
+    assessments: [],
+    assessmentCoMappings: [],
+    marks: [],
+    courseReports: []
+};
+
+let data = structuredClone(initialData);
+let lastMarkViewCourseId = '';
+let lastCoStudentFilter = null;
+let lastCoSemesterFilter = null;
+let lastPoStudentFilter = null;
+let lastPoSemesterFilter = null;
+let lastPoCoProgramId = null;
+
+async function loadInitialData() {
+    try {
+        await reloadDataFromServer(false);
+    } catch (error) {
+        console.error('Unable to load data from server. Using empty state.', error);
+        data = structuredClone(initialData);
+        alert('Unable to reach the server. Data entry will not persist until the backend is available.');
+    }
+}
+
+async function reloadDataFromServer(showAlertOnError = true) {
+    const response = await fetch(`${API_BASE}/data`);
+    if (!response.ok) {
+        const message = `Unable to load data from server (${response.status}).`;
+        if (showAlertOnError) {
+            alert(message);
+        }
+        throw new Error(message);
+    }
+    const payload = await response.json();
+    data = Object.assign(structuredClone(initialData), payload);
+}
+
+async function postJson(path, body) {
+    const response = await fetch(`${API_BASE}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+    });
+
+    if (!response.ok) {
+        let errorMessage = `Request failed with status ${response.status}`;
+        try {
+            const errorPayload = await response.json();
+            if (errorPayload?.error) {
+                errorMessage = errorPayload.error;
+            }
+        } catch (error) {
+            // ignore JSON parse errors
+        }
+        throw new Error(errorMessage);
+    }
+
+    return response.json();
+}
+
+function resetReports() {
+    document.getElementById('mark-view-content').innerHTML = '<p class="empty-state">Use the filter to view uploaded marks.</p>';
+    document.getElementById('co-student-report').innerHTML = '<p class="empty-state">Select a student and course to view CO attainment.</p>';
+    document.getElementById('co-semester-report').innerHTML = '<p class="empty-state">Select a course and semester to view aggregated attainment.</p>';
+    document.getElementById('po-student-report').innerHTML = '<p class="empty-state">Choose a student to view PO achievement.</p>';
+    document.getElementById('po-semester-report').innerHTML = '<p class="empty-state">Choose a program and semester to view PO achievement.</p>';
+    document.getElementById('po-co-content').innerHTML = '<p class="empty-state">Select a program to generate the mapping report.</p>';
+}
+
+function structuredClone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initializeApp();
+});
+
+async function initializeApp() {
+    await loadInitialData();
+    setupNavigation();
+    setupForms();
+    refreshSelectOptions();
+    renderAllTables();
+    resetReports();
+}
+
+function setupNavigation() {
+    const buttons = document.querySelectorAll('.app-nav button');
+    const sections = document.querySelectorAll('main section');
+
+    function showSection(id) {
+        sections.forEach(section => {
+            section.classList.toggle('active', section.id === id);
+        });
+        buttons.forEach(button => {
+            button.classList.toggle('active', button.dataset.section === id);
+        });
+    }
+
+    buttons.forEach(button => {
+        button.addEventListener('click', () => {
+            showSection(button.dataset.section);
+        });
+    });
+
+    showSection('dashboard');
+}
+
+function setupForms() {
+    document.getElementById('program-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = {
+            code: formData.get('code').trim(),
+            name: formData.get('name').trim(),
+            description: formData.get('description').trim()
+        };
+        if (!payload.code || !payload.name) {
+            alert('Program code and name are required.');
+            return;
+        }
+        try {
+            await postJson('/programs', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderProgramTable();
+        } catch (error) {
+            console.error('Failed to save program', error);
+            alert(error.message || 'Failed to save program.');
+        }
+    });
+
+    document.getElementById('semester-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = {
+            name: formData.get('name').trim(),
+            sequence: Number(formData.get('sequence'))
+        };
+        try {
+            await postJson('/semesters', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderSemesterTable();
+        } catch (error) {
+            console.error('Failed to save semester', error);
+            alert(error.message || 'Failed to save semester.');
+        }
+    });
+
+    document.getElementById('course-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = {
+            code: formData.get('code').trim(),
+            name: formData.get('name').trim(),
+            programId: formData.get('programId'),
+            semesterId: formData.get('semesterId'),
+            credits: Number(formData.get('credits'))
+        };
+        try {
+            await postJson('/courses', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderCourseTable();
+        } catch (error) {
+            console.error('Failed to save course', error);
+            alert(error.message || 'Failed to save course.');
+        }
+    });
+
+    document.getElementById('student-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = {
+            studentId: formData.get('studentId').trim(),
+            name: formData.get('name').trim(),
+            email: formData.get('email').trim(),
+            programId: formData.get('programId')
+        };
+        if (!payload.studentId || !payload.name || !payload.programId) {
+            alert('Student ID, name and program are required.');
+            return;
+        }
+        try {
+            await postJson('/students', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderStudentTable();
+        } catch (error) {
+            console.error('Failed to save student', error);
+            alert(error.message || 'Failed to save student.');
+        }
+    });
+
+    document.getElementById('enrolment-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const enrolmentKey = `${formData.get('studentId')}|${formData.get('courseId')}|${formData.get('semesterId')}|${formData.get('year')}`;
+        const alreadyExists = data.enrolments.some(enrol => `${enrol.studentId}|${enrol.courseId}|${enrol.semesterId}|${enrol.year}` === enrolmentKey);
+        if (alreadyExists) {
+            alert('The student is already enrolled in the selected course and semester.');
+            return;
+        }
+        const payload = {
+            studentId: formData.get('studentId'),
+            courseId: formData.get('courseId'),
+            semesterId: formData.get('semesterId'),
+            year: formData.get('year').trim()
+        };
+        try {
+            await postJson('/enrolments', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderEnrolmentTable();
+        } catch (error) {
+            console.error('Failed to save enrolment', error);
+            alert(error.message || 'Failed to save enrolment.');
+        }
+    });
+
+    document.getElementById('program-outcome-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const programOutcomeKey = `${formData.get('programId')}|${formData.get('code').trim().toUpperCase()}`;
+        const alreadyExists = data.programOutcomes.some(outcome => `${outcome.programId}|${outcome.code.toUpperCase()}` === programOutcomeKey);
+        if (alreadyExists) {
+            alert('A program outcome with the same code already exists for the selected program.');
+            return;
+        }
+        const payload = {
+            programId: formData.get('programId'),
+            code: formData.get('code').trim(),
+            description: formData.get('description').trim()
+        };
+        try {
+            await postJson('/programOutcomes', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderProgramOutcomeTable();
+            renderCoPoTable();
+        } catch (error) {
+            console.error('Failed to save program outcome', error);
+            alert(error.message || 'Failed to save program outcome.');
+        }
+    });
+
+    document.getElementById('course-outcome-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const courseOutcomeKey = `${formData.get('courseId')}|${formData.get('code').trim().toUpperCase()}`;
+        const alreadyExists = data.courseOutcomes.some(outcome => `${outcome.courseId}|${outcome.code.toUpperCase()}` === courseOutcomeKey);
+        if (alreadyExists) {
+            alert('A course outcome with the same code already exists for the selected course.');
+            return;
+        }
+        const payload = {
+            courseId: formData.get('courseId'),
+            code: formData.get('code').trim(),
+            description: formData.get('description').trim()
+        };
+        try {
+            await postJson('/courseOutcomes', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderCourseOutcomeTable();
+            renderCoPoTable();
+        } catch (error) {
+            console.error('Failed to save course outcome', error);
+            alert(error.message || 'Failed to save course outcome.');
+        }
+    });
+
+    document.getElementById('co-po-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const mappingKey = `${formData.get('courseOutcomeId')}|${formData.get('programOutcomeId')}`;
+        const alreadyExists = data.coPoMappings.some(mapping => `${mapping.courseOutcomeId}|${mapping.programOutcomeId}` === mappingKey);
+        if (alreadyExists) {
+            alert('A mapping between the selected CO and PO already exists.');
+            return;
+        }
+        const payload = {
+            courseOutcomeId: formData.get('courseOutcomeId'),
+            programOutcomeId: formData.get('programOutcomeId'),
+            weight: Number(formData.get('weight')) || 0
+        };
+        try {
+            await postJson('/coPoMappings', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            renderCoPoTable();
+        } catch (error) {
+            console.error('Failed to save CO-PO mapping', error);
+            alert(error.message || 'Failed to save CO-PO mapping.');
+        }
+    });
+
+    document.getElementById('assessment-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = {
+            courseId: formData.get('courseId'),
+            name: formData.get('name').trim(),
+            type: formData.get('type').trim(),
+            maxMarks: Number(formData.get('maxMarks')) || 0,
+            semesterId: formData.get('semesterId')
+        };
+        try {
+            await postJson('/assessments', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            refreshSelectOptions();
+            renderAssessmentTable();
+        } catch (error) {
+            console.error('Failed to save assessment', error);
+            alert(error.message || 'Failed to save assessment.');
+        }
+    });
+
+    document.getElementById('assessment-co-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const mappingKey = `${formData.get('assessmentId')}|${formData.get('courseOutcomeId')}`;
+        const alreadyExists = data.assessmentCoMappings.some(mapping => `${mapping.assessmentId}|${mapping.courseOutcomeId}` === mappingKey);
+        if (alreadyExists) {
+            alert('A mapping between the selected assessment and course outcome already exists.');
+            return;
+        }
+        const payload = {
+            assessmentId: formData.get('assessmentId'),
+            courseOutcomeId: formData.get('courseOutcomeId'),
+            weight: Number(formData.get('weight')) || 0
+        };
+        try {
+            await postJson('/assessmentCoMappings', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            renderAssessmentCoTable();
+        } catch (error) {
+            console.error('Failed to save assessment-CO mapping', error);
+            alert(error.message || 'Failed to save assessment-CO mapping.');
+        }
+    });
+
+    const markForm = document.getElementById('mark-form');
+    const markCourseSelect = markForm?.querySelector('select[name="courseId"]');
+    const markAssessmentSelect = markForm?.querySelector('select[name="assessmentId"]');
+    const markEnrolmentSelect = markForm?.querySelector('select[name="enrolmentId"]');
+
+    markCourseSelect?.addEventListener('change', () => {
+        updateMarkFormSelectors();
+    });
+
+    markForm?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = {
+            enrolmentId: formData.get('enrolmentId'),
+            assessmentId: formData.get('assessmentId'),
+            marks: Number(formData.get('marks'))
+        };
+        if (!payload.enrolmentId || !payload.assessmentId || Number.isNaN(payload.marks)) {
+            alert('Enrolment, assessment and marks are required.');
+            return;
+        }
+        try {
+            await postJson('/marks', payload);
+            event.target.reset();
+            if (markAssessmentSelect) {
+                markAssessmentSelect.value = '';
+            }
+            if (markEnrolmentSelect) {
+                markEnrolmentSelect.value = '';
+            }
+            await reloadDataFromServer();
+            updateMarkFormSelectors();
+            renderMarkTable();
+            renderMarkView(lastMarkViewCourseId);
+            regenerateReportsAfterMarkChange();
+        } catch (error) {
+            console.error('Failed to save marks', error);
+            alert(error.message || 'Failed to save marks.');
+        }
+    });
+
+    document.getElementById('course-report-form')?.addEventListener('submit', async event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        const payload = {
+            courseId: formData.get('courseId'),
+            semesterId: formData.get('semesterId'),
+            year: formData.get('year').trim(),
+            summary: formData.get('summary').trim(),
+            actions: formData.get('actions').trim()
+        };
+        try {
+            await postJson('/courseReports', payload);
+            event.target.reset();
+            await reloadDataFromServer();
+            renderCourseReportTable();
+        } catch (error) {
+            console.error('Failed to save course report', error);
+            alert(error.message || 'Failed to save course report.');
+        }
+    });
+
+    document.getElementById('mark-view-filter')?.addEventListener('submit', event => {
+        event.preventDefault();
+        const courseId = new FormData(event.target).get('courseId') || '';
+        lastMarkViewCourseId = courseId;
+        renderMarkView(courseId);
+    });
+
+    document.getElementById('co-student-filter')?.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        lastCoStudentFilter = {
+            studentId: formData.get('studentId'),
+            courseId: formData.get('courseId')
+        };
+        renderCoAchievementForStudent(lastCoStudentFilter.studentId, lastCoStudentFilter.courseId);
+    });
+
+    document.getElementById('co-semester-filter')?.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        lastCoSemesterFilter = {
+            courseId: formData.get('courseId'),
+            semesterId: formData.get('semesterId')
+        };
+        renderCoAchievementForSemester(lastCoSemesterFilter.courseId, lastCoSemesterFilter.semesterId);
+    });
+
+    document.getElementById('po-student-filter')?.addEventListener('submit', event => {
+        event.preventDefault();
+        const studentId = new FormData(event.target).get('studentId');
+        lastPoStudentFilter = { studentId };
+        renderPoAchievementForStudent(studentId);
+    });
+
+    document.getElementById('po-semester-filter')?.addEventListener('submit', event => {
+        event.preventDefault();
+        const formData = new FormData(event.target);
+        lastPoSemesterFilter = {
+            programId: formData.get('programId'),
+            semesterId: formData.get('semesterId')
+        };
+        renderPoAchievementForSemester(lastPoSemesterFilter.programId, lastPoSemesterFilter.semesterId);
+    });
+
+    document.getElementById('po-co-filter')?.addEventListener('submit', event => {
+        event.preventDefault();
+        const programId = new FormData(event.target).get('programId');
+        lastPoCoProgramId = programId;
+        renderPoCoReport(programId);
+    });
+}
+
+function refreshSelectOptions() {
+    const programOptions = data.programs
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(program => ({ value: program.id, label: `${program.code} — ${program.name}` }));
+
+    populateSelect(document.querySelector('#course-form select[name="programId"]'), programOptions);
+    populateSelect(document.querySelector('#student-form select[name="programId"]'), programOptions);
+    populateSelect(document.querySelector('#program-outcome-form select[name="programId"]'), programOptions);
+    populateSelect(document.querySelector('#po-semester-filter select[name="programId"]'), programOptions, { placeholder: 'Select program', allowEmpty: true });
+    populateSelect(document.querySelector('#po-co-filter select[name="programId"]'), programOptions, { placeholder: 'Select program', allowEmpty: false });
+
+    const semesterOptions = data.semesters
+        .slice()
+        .sort((a, b) => a.sequence - b.sequence)
+        .map(semester => ({ value: semester.id, label: `${semester.sequence}. ${semester.name}` }));
+
+    document.querySelectorAll('form select[name="semesterId"]').forEach(select => {
+        const allowEmpty = select.closest('form').id.includes('filter');
+        populateSelect(select, semesterOptions, { placeholder: 'Select semester', allowEmpty });
+    });
+
+    const courseOptions = data.courses
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(course => {
+            const program = getProgram(course.programId);
+            return {
+                value: course.id,
+                label: `${course.code} — ${course.name}${program ? ` (${program.code})` : ''}`
+            };
+        });
+
+    populateSelect(document.querySelector('#course-form select[name="courseId"]'), courseOptions);
+    populateSelect(document.querySelector('#course-outcome-form select[name="courseId"]'), courseOptions);
+    populateSelect(document.querySelector('#assessment-form select[name="courseId"]'), courseOptions);
+    populateSelect(document.querySelector('#enrolment-form select[name="courseId"]'), courseOptions);
+    populateSelect(document.querySelector('#mark-view-filter select[name="courseId"]'), courseOptions, { placeholder: 'All courses (optional)', allowEmpty: true });
+    populateSelect(document.querySelector('#co-student-filter select[name="courseId"]'), courseOptions);
+    populateSelect(document.querySelector('#co-semester-filter select[name="courseId"]'), courseOptions);
+    populateSelect(document.querySelector('#course-report-form select[name="courseId"]'), courseOptions);
+
+    populateSelect(document.querySelector('#mark-form select[name="courseId"]'), courseOptions);
+
+    const studentOptions = data.students
+        .slice()
+        .sort((a, b) => a.studentId.localeCompare(b.studentId))
+        .map(student => ({ value: student.id, label: `${student.studentId} — ${student.name}` }));
+
+    populateSelect(document.querySelector('#enrolment-form select[name="studentId"]'), studentOptions);
+    populateSelect(document.querySelector('#mark-form select[name="enrolmentId"]'), [], { placeholder: 'Select course first', allowEmpty: false });
+    populateSelect(document.querySelector('#co-student-filter select[name="studentId"]'), studentOptions);
+    populateSelect(document.querySelector('#po-student-filter select[name="studentId"]'), studentOptions);
+
+    const programOutcomeOptions = data.programOutcomes
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(outcome => {
+            const program = getProgram(outcome.programId);
+            return {
+                value: outcome.id,
+                label: `${outcome.code} — ${outcome.description}${program ? ` (${program.code})` : ''}`
+            };
+        });
+
+    populateSelect(document.querySelector('#co-po-form select[name="programOutcomeId"]'), programOutcomeOptions);
+
+    const courseOutcomeOptions = data.courseOutcomes
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(outcome => {
+            const course = getCourse(outcome.courseId);
+            return {
+                value: outcome.id,
+                label: `${outcome.code} — ${outcome.description}${course ? ` (${course.code})` : ''}`
+            };
+        });
+
+    populateSelect(document.querySelector('#co-po-form select[name="courseOutcomeId"]'), courseOutcomeOptions);
+    populateSelect(document.querySelector('#assessment-co-form select[name="courseOutcomeId"]'), courseOutcomeOptions);
+
+    const assessmentOptions = data.assessments
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(assessment => {
+            const course = getCourse(assessment.courseId);
+            return {
+                value: assessment.id,
+                label: `${assessment.name} — ${assessment.type}${course ? ` (${course.code})` : ''}`
+            };
+        });
+
+    populateSelect(document.querySelector('#assessment-co-form select[name="assessmentId"]'), assessmentOptions);
+
+    updateMarkFormSelectors();
+}
+
+function populateSelect(select, options, { placeholder = 'Select option', allowEmpty = false, autoSelectFirst = true } = {}) {
+    if (!select) return;
+    const previousValue = select.value;
+    select.innerHTML = '';
+
+    if (placeholder) {
+        const placeholderOption = document.createElement('option');
+        placeholderOption.value = '';
+        placeholderOption.textContent = placeholder;
+        placeholderOption.selected = true;
+        if (!allowEmpty) {
+            placeholderOption.disabled = true;
+        }
+        select.appendChild(placeholderOption);
+    }
+
+    options.forEach(option => {
+        const element = document.createElement('option');
+        element.value = option.value;
+        element.textContent = option.label;
+        select.appendChild(element);
+    });
+
+    if (options.some(option => option.value === previousValue)) {
+        select.value = previousValue;
+    } else if (!allowEmpty && options.length > 0 && autoSelectFirst) {
+        select.selectedIndex = 1; // First non-placeholder option
+    } else {
+        select.value = '';
+    }
+
+    select.disabled = !allowEmpty && options.length === 0;
+}
+
+function updateMarkFormSelectors() {
+    const markForm = document.getElementById('mark-form');
+    if (!markForm) return;
+
+    const courseId = markForm.querySelector('select[name="courseId"]').value;
+    const assessmentSelect = markForm.querySelector('select[name="assessmentId"]');
+    const enrolmentSelect = markForm.querySelector('select[name="enrolmentId"]');
+
+    const assessments = courseId
+        ? data.assessments
+            .filter(assessment => assessment.courseId === courseId)
+            .map(assessment => ({
+                value: assessment.id,
+                label: `${assessment.name} — ${assessment.type} (Max ${assessment.maxMarks})`
+            }))
+        : [];
+
+    populateSelect(assessmentSelect, assessments, {
+        placeholder: courseId ? 'Select assessment' : 'Select course first',
+        allowEmpty: false,
+        autoSelectFirst: false
+    });
+
+    const enrolments = courseId
+        ? data.enrolments
+            .filter(enrolment => enrolment.courseId === courseId)
+            .map(enrolment => {
+                const student = getStudent(enrolment.studentId);
+                const semester = getSemester(enrolment.semesterId);
+                return {
+                    value: enrolment.id,
+                    label: `${student ? student.name : 'Unknown'} — ${semester ? semester.name : 'Semester'} ${enrolment.year}`
+                };
+            })
+        : [];
+
+    populateSelect(enrolmentSelect, enrolments, {
+        placeholder: courseId ? 'Select student enrolment' : 'Select course first',
+        allowEmpty: false,
+        autoSelectFirst: false
+    });
+}
+
+function renderAllTables() {
+    renderProgramTable();
+    renderSemesterTable();
+    renderCourseTable();
+    renderStudentTable();
+    renderEnrolmentTable();
+    renderProgramOutcomeTable();
+    renderCourseOutcomeTable();
+    renderCoPoTable();
+    renderAssessmentTable();
+    renderAssessmentCoTable();
+    renderMarkTable();
+    renderCourseReportTable();
+}
+
+function renderProgramTable() {
+    const table = document.getElementById('program-table');
+    if (!table) return;
+    if (data.programs.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No programs recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.programs
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(program => `<tr><td>${program.code}</td><td>${program.name}</td><td>${program.description || '—'}</td></tr>`)
+        .join('');
+    table.innerHTML = `<thead><tr><th>Code</th><th>Name</th><th>Description</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderSemesterTable() {
+    const table = document.getElementById('semester-table');
+    if (!table) return;
+    if (data.semesters.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No semesters recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.semesters
+        .slice()
+        .sort((a, b) => a.sequence - b.sequence)
+        .map(semester => `<tr><td>${semester.sequence}</td><td>${semester.name}</td></tr>`)
+        .join('');
+    table.innerHTML = `<thead><tr><th>Sequence</th><th>Name</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderCourseTable() {
+    const table = document.getElementById('course-table');
+    if (!table) return;
+    if (data.courses.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No courses recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.courses
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(course => {
+            const program = getProgram(course.programId);
+            const semester = getSemester(course.semesterId);
+            return `<tr><td>${course.code}</td><td>${course.name}</td><td>${program ? program.code : '—'}</td><td>${semester ? semester.name : '—'}</td><td>${course.credits}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Code</th><th>Name</th><th>Program</th><th>Semester</th><th>Credits</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderStudentTable() {
+    const table = document.getElementById('student-table');
+    if (!table) return;
+    if (data.students.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No students recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.students
+        .slice()
+        .sort((a, b) => a.studentId.localeCompare(b.studentId))
+        .map(student => {
+            const program = getProgram(student.programId);
+            return `<tr><td>${student.studentId}</td><td>${student.name}</td><td>${student.email || '—'}</td><td>${program ? program.code : '—'}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Student ID</th><th>Name</th><th>Email</th><th>Program</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderEnrolmentTable() {
+    const table = document.getElementById('enrolment-table');
+    if (!table) return;
+    if (data.enrolments.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No enrolments recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.enrolments
+        .slice()
+        .map(enrolment => {
+            const student = getStudent(enrolment.studentId);
+            const course = getCourse(enrolment.courseId);
+            const semester = getSemester(enrolment.semesterId);
+            return `<tr><td>${student ? student.studentId : '—'}</td><td>${student ? student.name : '—'}</td><td>${course ? course.code : '—'}</td><td>${semester ? semester.name : '—'}</td><td>${enrolment.year}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Student ID</th><th>Student Name</th><th>Course</th><th>Semester</th><th>Academic Year</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderProgramOutcomeTable() {
+    const table = document.getElementById('program-outcome-table');
+    if (!table) return;
+    if (data.programOutcomes.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No program outcomes recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.programOutcomes
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(outcome => {
+            const program = getProgram(outcome.programId);
+            return `<tr><td>${outcome.code}</td><td>${program ? program.code : '—'}</td><td>${outcome.description}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Outcome Code</th><th>Program</th><th>Description</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderCourseOutcomeTable() {
+    const table = document.getElementById('course-outcome-table');
+    if (!table) return;
+    if (data.courseOutcomes.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No course outcomes recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.courseOutcomes
+        .slice()
+        .sort((a, b) => a.code.localeCompare(b.code))
+        .map(outcome => {
+            const course = getCourse(outcome.courseId);
+            return `<tr><td>${outcome.code}</td><td>${course ? course.code : '—'}</td><td>${outcome.description}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Outcome Code</th><th>Course</th><th>Description</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderCoPoTable() {
+    const table = document.getElementById('co-po-table');
+    if (!table) return;
+    if (data.coPoMappings.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No CO-PO mappings recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.coPoMappings
+        .slice()
+        .map(mapping => {
+            const courseOutcome = getCourseOutcome(mapping.courseOutcomeId);
+            const programOutcome = getProgramOutcome(mapping.programOutcomeId);
+            const course = courseOutcome ? getCourse(courseOutcome.courseId) : null;
+            return `<tr><td>${courseOutcome ? courseOutcome.code : '—'}</td><td>${course ? course.code : '—'}</td><td>${programOutcome ? programOutcome.code : '—'}</td><td>${mapping.weight}%</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Course Outcome</th><th>Course</th><th>Program Outcome</th><th>Weight</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderAssessmentTable() {
+    const table = document.getElementById('assessment-table');
+    if (!table) return;
+    if (data.assessments.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No assessments recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.assessments
+        .slice()
+        .map(assessment => {
+            const course = getCourse(assessment.courseId);
+            const semester = getSemester(assessment.semesterId);
+            return `<tr><td>${assessment.name}</td><td>${assessment.type}</td><td>${course ? course.code : '—'}</td><td>${semester ? semester.name : '—'}</td><td>${assessment.maxMarks}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Name</th><th>Type</th><th>Course</th><th>Semester</th><th>Max Marks</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderAssessmentCoTable() {
+    const table = document.getElementById('assessment-co-table');
+    if (!table) return;
+    if (data.assessmentCoMappings.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No assessment to CO mappings recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.assessmentCoMappings
+        .slice()
+        .map(mapping => {
+            const assessment = getAssessment(mapping.assessmentId);
+            const courseOutcome = getCourseOutcome(mapping.courseOutcomeId);
+            const course = assessment ? getCourse(assessment.courseId) : null;
+            return `<tr><td>${assessment ? assessment.name : '—'}</td><td>${course ? course.code : '—'}</td><td>${courseOutcome ? courseOutcome.code : '—'}</td><td>${mapping.weight}%</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Assessment</th><th>Course</th><th>Course Outcome</th><th>Contribution</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderMarkTable() {
+    const table = document.getElementById('mark-table');
+    if (!table) return;
+    if (data.marks.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No marks uploaded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.marks
+        .slice()
+        .map(entry => {
+            const enrolment = getEnrolment(entry.enrolmentId);
+            const student = enrolment ? getStudent(enrolment.studentId) : null;
+            const course = enrolment ? getCourse(enrolment.courseId) : null;
+            const assessment = getAssessment(entry.assessmentId);
+            return `<tr><td>${student ? student.studentId : '—'}</td><td>${student ? student.name : '—'}</td><td>${course ? course.code : '—'}</td><td>${assessment ? assessment.name : '—'}</td><td>${entry.marks}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Student ID</th><th>Name</th><th>Course</th><th>Assessment</th><th>Marks</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderCourseReportTable() {
+    const table = document.getElementById('course-report-table');
+    if (!table) return;
+    if (data.courseReports.length === 0) {
+        table.innerHTML = '<tbody><tr><td class="empty-state">No course reports recorded yet.</td></tr></tbody>';
+        return;
+    }
+    const rows = data.courseReports
+        .slice()
+        .map(report => {
+            const course = getCourse(report.courseId);
+            const semester = getSemester(report.semesterId);
+            return `<tr><td>${course ? course.code : '—'}</td><td>${semester ? semester.name : '—'}</td><td>${report.year}</td><td>${report.summary}</td><td>${report.actions}</td></tr>`;
+        })
+        .join('');
+    table.innerHTML = `<thead><tr><th>Course</th><th>Semester</th><th>Academic Year</th><th>Summary</th><th>Improvement Actions</th></tr></thead><tbody>${rows}</tbody>`;
+}
+
+function renderMarkView(courseId) {
+    const container = document.getElementById('mark-view-content');
+    if (!container) return;
+    if (!courseId) {
+        container.innerHTML = '<p class="empty-state">Select a course to view uploaded marks.</p>';
+        return;
+    }
+    const course = getCourse(courseId);
+    const assessments = data.assessments.filter(assessment => assessment.courseId === courseId);
+    if (assessments.length === 0) {
+        container.innerHTML = '<p class="empty-state">No assessments configured for the selected course.</p>';
+        return;
+    }
+    const enrolments = data.enrolments.filter(enrolment => enrolment.courseId === courseId);
+    if (enrolments.length === 0) {
+        container.innerHTML = '<p class="empty-state">No student enrolments found for the selected course.</p>';
+        return;
+    }
+    const headers = assessments.map(assessment => `<th>${assessment.name}<br><span class="muted">Max ${assessment.maxMarks}</span></th>`).join('');
+    const rows = enrolments.map(enrolment => {
+        const student = getStudent(enrolment.studentId);
+        const cells = assessments.map(assessment => {
+            const mark = data.marks.find(entry => entry.enrolmentId === enrolment.id && entry.assessmentId === assessment.id);
+            return `<td>${mark ? mark.marks : '—'}</td>`;
+        }).join('');
+        return `<tr><td>${student ? student.studentId : '—'}<br>${student ? student.name : ''}</td>${cells}</tr>`;
+    }).join('');
+    container.innerHTML = `<table class="report-table"><thead><tr><th>Student</th>${headers}</tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function renderCoAchievementForStudent(studentId, courseId) {
+    const container = document.getElementById('co-student-report');
+    if (!container) return;
+    if (!studentId || !courseId) {
+        container.innerHTML = '<p class="empty-state">Select a student and course to view attainment.</p>';
+        return;
+    }
+    const enrolment = findLatestEnrolment(studentId, courseId);
+    if (!enrolment) {
+        container.innerHTML = '<p class="empty-state">No enrolment found for the selected student and course.</p>';
+        return;
+    }
+    const courseOutcomes = data.courseOutcomes.filter(outcome => outcome.courseId === courseId);
+    if (courseOutcomes.length === 0) {
+        container.innerHTML = '<p class="empty-state">No course outcomes configured for the selected course.</p>';
+        return;
+    }
+    const rows = courseOutcomes.map(outcome => {
+        const attainment = calculateCourseOutcomeAchievement(enrolment, outcome.id);
+        if (attainment === null) {
+            return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>—</td><td>No assessment mapping</td></tr>`;
+        }
+        const status = attainment >= 60 ? 'Achieved' : 'Needs Attention';
+        return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>${formatPercentage(attainment)}</td><td>${status}</td></tr>`;
+    }).join('');
+    container.innerHTML = `<table class="report-table"><thead><tr><th>Course Outcome</th><th>Description</th><th>Achievement</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function renderCoAchievementForSemester(courseId, semesterId) {
+    const container = document.getElementById('co-semester-report');
+    if (!container) return;
+    if (!courseId || !semesterId) {
+        container.innerHTML = '<p class="empty-state">Select a course and semester to view attainment.</p>';
+        return;
+    }
+    const enrolments = data.enrolments.filter(enrolment => enrolment.courseId === courseId && enrolment.semesterId === semesterId);
+    if (enrolments.length === 0) {
+        container.innerHTML = '<p class="empty-state">No enrolments found for the selected course and semester.</p>';
+        return;
+    }
+    const courseOutcomes = data.courseOutcomes.filter(outcome => outcome.courseId === courseId);
+    if (courseOutcomes.length === 0) {
+        container.innerHTML = '<p class="empty-state">No course outcomes configured for the selected course.</p>';
+        return;
+    }
+    const rows = courseOutcomes.map(outcome => {
+        const attainments = enrolments
+            .map(enrolment => calculateCourseOutcomeAchievement(enrolment, outcome.id))
+            .filter(value => value !== null);
+        if (attainments.length === 0) {
+            return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>—</td><td>No marks uploaded</td></tr>`;
+        }
+        const average = attainments.reduce((sum, value) => sum + value, 0) / attainments.length;
+        const status = average >= 60 ? 'Achieved' : 'Needs Attention';
+        return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>${formatPercentage(average)}</td><td>${status}</td></tr>`;
+    }).join('');
+    container.innerHTML = `<table class="report-table"><thead><tr><th>Course Outcome</th><th>Description</th><th>Average Achievement</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function renderPoAchievementForStudent(studentId) {
+    const container = document.getElementById('po-student-report');
+    if (!container) return;
+    if (!studentId) {
+        container.innerHTML = '<p class="empty-state">Select a student to generate the report.</p>';
+        return;
+    }
+    const student = getStudent(studentId);
+    if (!student) {
+        container.innerHTML = '<p class="empty-state">Student not found.</p>';
+        return;
+    }
+    const programOutcomes = data.programOutcomes.filter(outcome => outcome.programId === student.programId);
+    if (programOutcomes.length === 0) {
+        container.innerHTML = '<p class="empty-state">No program outcomes configured for the student\'s program.</p>';
+        return;
+    }
+    const results = programOutcomes.map(outcome => {
+        const attainment = calculateProgramOutcomeAchievementForStudent(studentId, outcome.id);
+        return { outcome, attainment };
+    });
+    const rows = results.map(({ outcome, attainment }) => {
+        if (attainment === null) {
+            return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>—</td><td>No contributing CO attainment</td></tr>`;
+        }
+        const status = attainment >= 60 ? 'Achieved' : 'Needs Attention';
+        return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>${formatPercentage(attainment)}</td><td>${status}</td></tr>`;
+    }).join('');
+    container.innerHTML = `<table class="report-table"><thead><tr><th>Program Outcome</th><th>Description</th><th>Achievement</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function renderPoAchievementForSemester(programId, semesterId) {
+    const container = document.getElementById('po-semester-report');
+    if (!container) return;
+    if (!programId || !semesterId) {
+        container.innerHTML = '<p class="empty-state">Select a program and semester to generate the report.</p>';
+        return;
+    }
+    const programOutcomes = data.programOutcomes.filter(outcome => outcome.programId === programId);
+    if (programOutcomes.length === 0) {
+        container.innerHTML = '<p class="empty-state">No program outcomes configured for the selected program.</p>';
+        return;
+    }
+    const students = data.students.filter(student => student.programId === programId);
+    const rows = programOutcomes.map(outcome => {
+        const attainments = students
+            .map(student => calculateProgramOutcomeAchievementForStudent(student.id, outcome.id, { semesterId }))
+            .filter(value => value !== null);
+        if (attainments.length === 0) {
+            return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>—</td><td>No contributing data</td></tr>`;
+        }
+        const average = attainments.reduce((sum, value) => sum + value, 0) / attainments.length;
+        const status = average >= 60 ? 'Achieved' : 'Needs Attention';
+        return `<tr><td>${outcome.code}</td><td>${outcome.description}</td><td>${formatPercentage(average)}</td><td>${status}</td></tr>`;
+    }).join('');
+    container.innerHTML = `<table class="report-table"><thead><tr><th>Program Outcome</th><th>Description</th><th>Average Achievement</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function renderPoCoReport(programId) {
+    const container = document.getElementById('po-co-content');
+    if (!container) return;
+    if (!programId) {
+        container.innerHTML = '<p class="empty-state">Select a program to generate the mapping report.</p>';
+        return;
+    }
+    const program = getProgram(programId);
+    if (!program) {
+        container.innerHTML = '<p class="empty-state">Program not found.</p>';
+        return;
+    }
+    const programOutcomes = data.programOutcomes.filter(outcome => outcome.programId === programId);
+    const courses = data.courses.filter(course => course.programId === programId);
+    const courseIds = new Set(courses.map(course => course.id));
+    const courseOutcomes = data.courseOutcomes.filter(outcome => courseIds.has(outcome.courseId));
+    if (programOutcomes.length === 0 || courseOutcomes.length === 0) {
+        container.innerHTML = '<p class="empty-state">Add course outcomes and program outcomes to view the mapping.</p>';
+        return;
+    }
+    const mappingMap = new Map();
+    data.coPoMappings.forEach(mapping => {
+        const key = `${mapping.courseOutcomeId}|${mapping.programOutcomeId}`;
+        mappingMap.set(key, mapping.weight);
+    });
+    const headerRow = programOutcomes.map(outcome => `<th>${outcome.code}</th>`).join('');
+    const rows = courseOutcomes.map(outcome => {
+        const cells = programOutcomes.map(po => {
+            const weight = mappingMap.get(`${outcome.id}|${po.id}`);
+            return `<td>${weight !== undefined ? weight + '%' : '—'}</td>`;
+        }).join('');
+        const course = getCourse(outcome.courseId);
+        return `<tr><td>${outcome.code}${course ? `<br><span class="muted">${course.code}</span>` : ''}</td>${cells}</tr>`;
+    }).join('');
+    container.innerHTML = `<h3>${program.name}</h3><table class="report-table"><thead><tr><th>Course Outcomes</th>${headerRow}</tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function calculateCourseOutcomeAchievement(enrolment, courseOutcomeId) {
+    const relevantMappings = data.assessmentCoMappings.filter(mapping => mapping.courseOutcomeId === courseOutcomeId);
+    if (relevantMappings.length === 0) {
+        return null;
+    }
+    let totalWeightedMax = 0;
+    let totalWeightedScore = 0;
+    relevantMappings.forEach(mapping => {
+        const assessment = getAssessment(mapping.assessmentId);
+        if (!assessment || assessment.courseId !== enrolment.courseId) {
+            return;
+        }
+        const weight = mapping.weight && mapping.weight > 0 ? mapping.weight / 100 : 1;
+        const markEntry = data.marks.find(entry => entry.enrolmentId === enrolment.id && entry.assessmentId === assessment.id);
+        totalWeightedMax += assessment.maxMarks * weight;
+        totalWeightedScore += (markEntry ? markEntry.marks : 0) * weight;
+    });
+    if (totalWeightedMax === 0) {
+        return null;
+    }
+    return (totalWeightedScore / totalWeightedMax) * 100;
+}
+
+function calculateProgramOutcomeAchievementForStudent(studentId, programOutcomeId, { semesterId = null } = {}) {
+    const programOutcome = getProgramOutcome(programOutcomeId);
+    if (!programOutcome) {
+        return null;
+    }
+    const enrolments = data.enrolments.filter(enrolment => enrolment.studentId === studentId && (!semesterId || enrolment.semesterId === semesterId));
+    if (enrolments.length === 0) {
+        return null;
+    }
+    const relevantMappings = data.coPoMappings.filter(mapping => mapping.programOutcomeId === programOutcomeId);
+    if (relevantMappings.length === 0) {
+        return null;
+    }
+    let totalWeight = 0;
+    let weightedSum = 0;
+    relevantMappings.forEach(mapping => {
+        const courseOutcome = getCourseOutcome(mapping.courseOutcomeId);
+        if (!courseOutcome) return;
+        const enrolmentsForCourse = enrolments.filter(enrolment => enrolment.courseId === courseOutcome.courseId);
+        if (enrolmentsForCourse.length === 0) return;
+        const attainments = enrolmentsForCourse
+            .map(enrolment => calculateCourseOutcomeAchievement(enrolment, courseOutcome.id))
+            .filter(value => value !== null);
+        if (attainments.length === 0) return;
+        const average = attainments.reduce((sum, value) => sum + value, 0) / attainments.length;
+        const weight = mapping.weight && mapping.weight > 0 ? mapping.weight : 100;
+        totalWeight += weight;
+        weightedSum += average * weight;
+    });
+    if (totalWeight === 0) {
+        return null;
+    }
+    return weightedSum / totalWeight;
+}
+
+function regenerateReportsAfterMarkChange() {
+    if (lastCoStudentFilter) {
+        renderCoAchievementForStudent(lastCoStudentFilter.studentId, lastCoStudentFilter.courseId);
+    }
+    if (lastCoSemesterFilter) {
+        renderCoAchievementForSemester(lastCoSemesterFilter.courseId, lastCoSemesterFilter.semesterId);
+    }
+    if (lastPoStudentFilter) {
+        renderPoAchievementForStudent(lastPoStudentFilter.studentId);
+    }
+    if (lastPoSemesterFilter) {
+        renderPoAchievementForSemester(lastPoSemesterFilter.programId, lastPoSemesterFilter.semesterId);
+    }
+    if (lastPoCoProgramId) {
+        renderPoCoReport(lastPoCoProgramId);
+    }
+}
+
+function findLatestEnrolment(studentId, courseId) {
+    const enrolments = data.enrolments.filter(enrolment => enrolment.studentId === studentId && enrolment.courseId === courseId);
+    if (enrolments.length === 0) {
+        return null;
+    }
+    return enrolments[enrolments.length - 1];
+}
+
+function formatPercentage(value) {
+    return `${value.toFixed(2)}%`;
+}
+
+function getProgram(id) {
+    return data.programs.find(program => program.id === id) || null;
+}
+
+function getSemester(id) {
+    return data.semesters.find(semester => semester.id === id) || null;
+}
+
+function getCourse(id) {
+    return data.courses.find(course => course.id === id) || null;
+}
+
+function getStudent(id) {
+    return data.students.find(student => student.id === id) || null;
+}
+
+function getEnrolment(id) {
+    return data.enrolments.find(enrolment => enrolment.id === id) || null;
+}
+
+function getProgramOutcome(id) {
+    return data.programOutcomes.find(outcome => outcome.id === id) || null;
+}
+
+function getCourseOutcome(id) {
+    return data.courseOutcomes.find(outcome => outcome.id === id) || null;
+}
+
+function getAssessment(id) {
+    return data.assessments.find(assessment => assessment.id === id) || null;
+}

--- a/data.json
+++ b/data.json
@@ -1,0 +1,14 @@
+{
+  "programs": [],
+  "semesters": [],
+  "courses": [],
+  "students": [],
+  "enrolments": [],
+  "programOutcomes": [],
+  "courseOutcomes": [],
+  "coPoMappings": [],
+  "assessments": [],
+  "assessmentCoMappings": [],
+  "marks": [],
+  "courseReports": []
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OBE Management Portal</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="app-header">
+        <h1>Outcome Based Education Management</h1>
+        <p class="subtitle">Unified workspace for program, course, assessment and achievement tracking</p>
+    </header>
+
+    <nav class="app-nav">
+        <button data-section="dashboard" class="active">Dashboard</button>
+        <button data-section="basic-setup">Basic Setups</button>
+        <button data-section="courses">Course Entry</button>
+        <button data-section="students">Student Entry</button>
+        <button data-section="enrolments">Enrolment Entry</button>
+        <button data-section="program-outcomes">Program Outcomes</button>
+        <button data-section="course-outcomes">Course Outcomes</button>
+        <button data-section="co-po-mapping">CO-PO Mapping</button>
+        <button data-section="assessments">Assessment Setup</button>
+        <button data-section="assessment-co">Assessment-CO Mapping</button>
+        <button data-section="marks">Mark Uploading</button>
+        <button data-section="mark-view">Mark View</button>
+        <button data-section="co-achievement-student">CO Achievement (Student)</button>
+        <button data-section="co-achievement-semester">CO Achievement (Semester)</button>
+        <button data-section="po-achievement-student">PO Achievement (Student)</button>
+        <button data-section="po-achievement-semester">PO Achievement (Semester)</button>
+        <button data-section="po-co-report">PO-CO Report</button>
+        <button data-section="course-report">Course CQI Reports</button>
+    </nav>
+
+    <main>
+        <section id="dashboard" class="active">
+            <div class="intro">
+                <h2>Welcome to the OBE Management Portal</h2>
+                <p>Use the navigation to manage programs, courses, outcomes, assessments, and achievement reports. The workspace stores data locally in your browser so you can prototype your OBE workflows instantly without server setup.</p>
+                <div class="info-grid">
+                    <div class="info-card">
+                        <h3>Program Planning</h3>
+                        <p>Define academic programs, semesters, and program outcomes. Build alignment between course outcomes and program expectations.</p>
+                    </div>
+                    <div class="info-card">
+                        <h3>Assessment Tracking</h3>
+                        <p>Configure course assessments, map them to course outcomes, and upload marks for enrolled students.</p>
+                    </div>
+                    <div class="info-card">
+                        <h3>Achievement Analytics</h3>
+                        <p>Generate course outcome and program outcome achievement reports for individuals, courses, and semesters.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="basic-setup">
+            <h2>Basic Setups</h2>
+            <div class="section-grid">
+                <div class="card">
+                    <h3>Add Program</h3>
+                    <form id="program-form" class="form-grid">
+                        <label>Program Code<input type="text" name="code" required></label>
+                        <label>Program Name<input type="text" name="name" required></label>
+                        <label>Description<textarea name="description" rows="3"></textarea></label>
+                        <button type="submit">Save Program</button>
+                    </form>
+                </div>
+                <div class="card">
+                    <h3>Add Semester</h3>
+                    <form id="semester-form" class="form-grid">
+                        <label>Semester Name<input type="text" name="name" required></label>
+                        <label>Sequence<input type="number" name="sequence" min="1" required></label>
+                        <button type="submit">Save Semester</button>
+                    </form>
+                </div>
+            </div>
+            <div class="card">
+                <h3>Programs</h3>
+                <table id="program-table" class="data-table"></table>
+            </div>
+            <div class="card">
+                <h3>Semesters</h3>
+                <table id="semester-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="courses">
+            <h2>Course Entry</h2>
+            <div class="card">
+                <form id="course-form" class="form-grid">
+                    <label>Course Code<input type="text" name="code" required></label>
+                    <label>Course Name<input type="text" name="name" required></label>
+                    <label>Program<select name="programId" required></select></label>
+                    <label>Semester<select name="semesterId" required></select></label>
+                    <label>Credit Value<input type="number" name="credits" min="0" step="0.5" required></label>
+                    <button type="submit">Save Course</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="course-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="students">
+            <h2>Student Entry</h2>
+            <div class="card">
+                <form id="student-form" class="form-grid">
+                    <label>Student ID<input type="text" name="studentId" required></label>
+                    <label>Full Name<input type="text" name="name" required></label>
+                    <label>Email<input type="email" name="email"></label>
+                    <label>Program<select name="programId" required></select></label>
+                    <button type="submit">Save Student</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="student-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="enrolments">
+            <h2>Enrolment Entry</h2>
+            <div class="card">
+                <form id="enrolment-form" class="form-grid">
+                    <label>Student<select name="studentId" required></select></label>
+                    <label>Course<select name="courseId" required></select></label>
+                    <label>Semester<select name="semesterId" required></select></label>
+                    <label>Academic Year<input type="text" name="year" placeholder="2024-2025" required></label>
+                    <button type="submit">Save Enrolment</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="enrolment-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="program-outcomes">
+            <h2>Program Outcome Setup</h2>
+            <div class="card">
+                <form id="program-outcome-form" class="form-grid">
+                    <label>Program<select name="programId" required></select></label>
+                    <label>Outcome Code<input type="text" name="code" required></label>
+                    <label>Description<textarea name="description" rows="3" required></textarea></label>
+                    <button type="submit">Save Program Outcome</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="program-outcome-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="course-outcomes">
+            <h2>Course Outcome Setup</h2>
+            <div class="card">
+                <form id="course-outcome-form" class="form-grid">
+                    <label>Course<select name="courseId" required></select></label>
+                    <label>Outcome Code<input type="text" name="code" required></label>
+                    <label>Description<textarea name="description" rows="3" required></textarea></label>
+                    <button type="submit">Save Course Outcome</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="course-outcome-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="co-po-mapping">
+            <h2>CO-PO Mapping</h2>
+            <div class="card">
+                <form id="co-po-form" class="form-grid">
+                    <label>Course Outcome<select name="courseOutcomeId" required></select></label>
+                    <label>Program Outcome<select name="programOutcomeId" required></select></label>
+                    <label>Weight (%)<input type="number" name="weight" min="0" max="100" value="100" required></label>
+                    <button type="submit">Save Mapping</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="co-po-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="assessments">
+            <h2>Assessment Setup</h2>
+            <div class="card">
+                <form id="assessment-form" class="form-grid">
+                    <label>Course<select name="courseId" required></select></label>
+                    <label>Assessment Name<input type="text" name="name" required></label>
+                    <label>Type<input type="text" name="type" placeholder="Quiz, Midterm, Final" required></label>
+                    <label>Max Marks<input type="number" name="maxMarks" min="0" required></label>
+                    <label>Semester<select name="semesterId" required></select></label>
+                    <button type="submit">Save Assessment</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="assessment-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="assessment-co">
+            <h2>Assessment - Course Outcome Mapping</h2>
+            <div class="card">
+                <form id="assessment-co-form" class="form-grid">
+                    <label>Assessment<select name="assessmentId" required></select></label>
+                    <label>Course Outcome<select name="courseOutcomeId" required></select></label>
+                    <label>Contribution (%)<input type="number" name="weight" min="0" max="100" value="100" required></label>
+                    <button type="submit">Save Mapping</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="assessment-co-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="marks">
+            <h2>Mark Uploading</h2>
+            <div class="card">
+                <form id="mark-form" class="form-grid">
+                    <label>Course<select name="courseId" required></select></label>
+                    <label>Assessment<select name="assessmentId" required></select></label>
+                    <label>Student<select name="enrolmentId" required></select></label>
+                    <label>Marks Obtained<input type="number" name="marks" min="0" step="0.01" required></label>
+                    <button type="submit">Save Marks</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="mark-table" class="data-table"></table>
+            </div>
+        </section>
+
+        <section id="mark-view">
+            <h2>Mark View</h2>
+            <div class="card">
+                <form id="mark-view-filter" class="filter-grid">
+                    <label>Course<select name="courseId"></select></label>
+                    <button type="submit">View Marks</button>
+                </form>
+                <div id="mark-view-content" class="scrollable"></div>
+            </div>
+        </section>
+
+        <section id="co-achievement-student">
+            <h2>CO Achievement Report (Per Student)</h2>
+            <div class="card">
+                <form id="co-student-filter" class="filter-grid">
+                    <label>Student<select name="studentId" required></select></label>
+                    <label>Course<select name="courseId" required></select></label>
+                    <button type="submit">Generate Report</button>
+                </form>
+                <div id="co-student-report" class="scrollable"></div>
+            </div>
+        </section>
+
+        <section id="co-achievement-semester">
+            <h2>CO Achievement Report (Per Semester)</h2>
+            <div class="card">
+                <form id="co-semester-filter" class="filter-grid">
+                    <label>Course<select name="courseId" required></select></label>
+                    <label>Semester<select name="semesterId" required></select></label>
+                    <button type="submit">Generate Report</button>
+                </form>
+                <div id="co-semester-report" class="scrollable"></div>
+            </div>
+        </section>
+
+        <section id="po-achievement-student">
+            <h2>PO Achievement Report (Per Student)</h2>
+            <div class="card">
+                <form id="po-student-filter" class="filter-grid">
+                    <label>Student<select name="studentId" required></select></label>
+                    <button type="submit">Generate Report</button>
+                </form>
+                <div id="po-student-report" class="scrollable"></div>
+            </div>
+        </section>
+
+        <section id="po-achievement-semester">
+            <h2>PO Achievement Report (Per Semester)</h2>
+            <div class="card">
+                <form id="po-semester-filter" class="filter-grid">
+                    <label>Program<select name="programId" required></select></label>
+                    <label>Semester<select name="semesterId" required></select></label>
+                    <button type="submit">Generate Report</button>
+                </form>
+                <div id="po-semester-report" class="scrollable"></div>
+            </div>
+        </section>
+
+        <section id="po-co-report">
+            <h2>PO-CO Mapping Report</h2>
+            <div class="card">
+                <form id="po-co-filter" class="filter-grid">
+                    <label>Program<select name="programId" required></select></label>
+                    <button type="submit">Generate Mapping</button>
+                </form>
+                <div id="po-co-content" class="scrollable"></div>
+            </div>
+        </section>
+
+        <section id="course-report">
+            <h2>Course Report Entry for CQI</h2>
+            <div class="card">
+                <form id="course-report-form" class="form-grid">
+                    <label>Course<select name="courseId" required></select></label>
+                    <label>Semester<select name="semesterId" required></select></label>
+                    <label>Academic Year<input type="text" name="year" placeholder="2024-2025" required></label>
+                    <label>Summary<textarea name="summary" rows="3" required></textarea></label>
+                    <label>Improvement Actions<textarea name="actions" rows="3" required></textarea></label>
+                    <button type="submit">Save Course Report</button>
+                </form>
+            </div>
+            <div class="card">
+                <table id="course-report-table" class="data-table"></table>
+            </div>
+        </section>
+    </main>
+
+    <footer class="app-footer">
+        <p>Data is stored locally in your browser. Export functionality can be added by extending <code>app.js</code>.</p>
+    </footer>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "obe-portal",
+  "version": "1.0.0",
+  "description": "Outcome Based Education management portal with Node.js backend",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "obe",
+    "education",
+    "express"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,583 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs/promises');
+const crypto = require('crypto');
+
+const PORT = process.env.PORT || 3000;
+const DATA_FILE = path.join(__dirname, 'data.json');
+
+const initialData = {
+  programs: [],
+  semesters: [],
+  courses: [],
+  students: [],
+  enrolments: [],
+  programOutcomes: [],
+  courseOutcomes: [],
+  coPoMappings: [],
+  assessments: [],
+  assessmentCoMappings: [],
+  marks: [],
+  courseReports: []
+};
+
+class ValidationError extends Error {
+  constructor(message, status = 400) {
+    super(message);
+    this.name = 'ValidationError';
+    this.status = status;
+  }
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function generateId() {
+  return `id-${crypto.randomBytes(8).toString('hex')}${Date.now().toString(16)}`;
+}
+
+class DataStore {
+  constructor(filePath, seed) {
+    this.filePath = filePath;
+    this.seed = clone(seed);
+    this.data = clone(seed);
+  }
+
+  async init() {
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw);
+      this.data = clone(this.seed);
+      for (const key of Object.keys(this.seed)) {
+        if (Array.isArray(parsed[key])) {
+          this.data[key] = parsed[key];
+        }
+      }
+      await this.save();
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        await this.save();
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async save() {
+    await fs.writeFile(this.filePath, JSON.stringify(this.data, null, 2));
+  }
+
+  getAll() {
+    return clone(this.data);
+  }
+
+  list(collection) {
+    if (!Object.prototype.hasOwnProperty.call(this.data, collection)) {
+      throw new ValidationError(`Unknown collection: ${collection}`, 404);
+    }
+    return clone(this.data[collection]);
+  }
+
+  findById(collection, id) {
+    return this.data[collection].find((item) => item.id === id);
+  }
+
+  async addProgram(payload) {
+    const code = (payload.code || '').trim();
+    const name = (payload.name || '').trim();
+    const description = (payload.description || '').trim();
+
+    if (!code || !name) {
+      throw new ValidationError('Program code and name are required.');
+    }
+
+    const exists = this.data.programs.some(
+      (program) => program.code.toLowerCase() === code.toLowerCase()
+    );
+
+    if (exists) {
+      throw new ValidationError('A program with this code already exists.', 409);
+    }
+
+    const program = { id: generateId(), code, name, description };
+    this.data.programs.push(program);
+    await this.save();
+    return program;
+  }
+
+  async addSemester(payload) {
+    const name = (payload.name || '').trim();
+    const sequence = Number(payload.sequence);
+
+    if (!name || Number.isNaN(sequence)) {
+      throw new ValidationError('Semester name and sequence are required.');
+    }
+
+    const semester = { id: generateId(), name, sequence };
+    this.data.semesters.push(semester);
+    await this.save();
+    return semester;
+  }
+
+  async addCourse(payload) {
+    const code = (payload.code || '').trim();
+    const name = (payload.name || '').trim();
+    const programId = payload.programId;
+    const semesterId = payload.semesterId;
+    const credits = Number(payload.credits);
+
+    if (!code || !name || !programId || !semesterId || Number.isNaN(credits)) {
+      throw new ValidationError('Course code, name, program, semester and credits are required.');
+    }
+
+    if (!this.findById('programs', programId)) {
+      throw new ValidationError('Referenced program does not exist.');
+    }
+
+    if (!this.findById('semesters', semesterId)) {
+      throw new ValidationError('Referenced semester does not exist.');
+    }
+
+    const course = { id: generateId(), code, name, programId, semesterId, credits };
+    this.data.courses.push(course);
+    await this.save();
+    return course;
+  }
+
+  async addStudent(payload) {
+    const studentId = (payload.studentId || '').trim();
+    const name = (payload.name || '').trim();
+    const email = (payload.email || '').trim();
+    const programId = payload.programId;
+
+    if (!studentId || !name || !programId) {
+      throw new ValidationError('Student ID, name and program are required.');
+    }
+
+    if (!this.findById('programs', programId)) {
+      throw new ValidationError('Referenced program does not exist.');
+    }
+
+    const existing = this.data.students.some(
+      (student) => student.studentId.toLowerCase() === studentId.toLowerCase()
+    );
+
+    if (existing) {
+      throw new ValidationError('A student with this ID already exists.', 409);
+    }
+
+    const student = { id: generateId(), studentId, name, email, programId };
+    this.data.students.push(student);
+    await this.save();
+    return student;
+  }
+
+  async addEnrolment(payload) {
+    const studentId = payload.studentId;
+    const courseId = payload.courseId;
+    const semesterId = payload.semesterId;
+    const year = (payload.year || '').trim();
+
+    if (!studentId || !courseId || !semesterId || !year) {
+      throw new ValidationError('Student, course, semester and academic year are required.');
+    }
+
+    if (!this.findById('students', studentId)) {
+      throw new ValidationError('Referenced student does not exist.');
+    }
+
+    if (!this.findById('courses', courseId)) {
+      throw new ValidationError('Referenced course does not exist.');
+    }
+
+    if (!this.findById('semesters', semesterId)) {
+      throw new ValidationError('Referenced semester does not exist.');
+    }
+
+    const composite = `${studentId}|${courseId}|${semesterId}|${year}`;
+    const exists = this.data.enrolments.some((enrolment) => {
+      return `${enrolment.studentId}|${enrolment.courseId}|${enrolment.semesterId}|${enrolment.year}` === composite;
+    });
+
+    if (exists) {
+      throw new ValidationError('Enrolment already exists for the provided student, course, semester and year.', 409);
+    }
+
+    const enrolment = { id: generateId(), studentId, courseId, semesterId, year };
+    this.data.enrolments.push(enrolment);
+    await this.save();
+    return enrolment;
+  }
+
+  async addProgramOutcome(payload) {
+    const programId = payload.programId;
+    const code = (payload.code || '').trim();
+    const description = (payload.description || '').trim();
+
+    if (!programId || !code) {
+      throw new ValidationError('Program and outcome code are required.');
+    }
+
+    if (!this.findById('programs', programId)) {
+      throw new ValidationError('Referenced program does not exist.');
+    }
+
+    const composite = `${programId}|${code.toLowerCase()}`;
+    const exists = this.data.programOutcomes.some((outcome) => {
+      return `${outcome.programId}|${outcome.code.toLowerCase()}` === composite;
+    });
+
+    if (exists) {
+      throw new ValidationError('An outcome with this code already exists for the program.', 409);
+    }
+
+    const programOutcome = { id: generateId(), programId, code, description };
+    this.data.programOutcomes.push(programOutcome);
+    await this.save();
+    return programOutcome;
+  }
+
+  async addCourseOutcome(payload) {
+    const courseId = payload.courseId;
+    const code = (payload.code || '').trim();
+    const description = (payload.description || '').trim();
+
+    if (!courseId || !code) {
+      throw new ValidationError('Course and outcome code are required.');
+    }
+
+    if (!this.findById('courses', courseId)) {
+      throw new ValidationError('Referenced course does not exist.');
+    }
+
+    const composite = `${courseId}|${code.toLowerCase()}`;
+    const exists = this.data.courseOutcomes.some((outcome) => {
+      return `${outcome.courseId}|${outcome.code.toLowerCase()}` === composite;
+    });
+
+    if (exists) {
+      throw new ValidationError('An outcome with this code already exists for the course.', 409);
+    }
+
+    const courseOutcome = { id: generateId(), courseId, code, description };
+    this.data.courseOutcomes.push(courseOutcome);
+    await this.save();
+    return courseOutcome;
+  }
+
+  async addCoPoMapping(payload) {
+    const courseOutcomeId = payload.courseOutcomeId;
+    const programOutcomeId = payload.programOutcomeId;
+    const weight = Number(payload.weight);
+
+    if (!courseOutcomeId || !programOutcomeId || Number.isNaN(weight)) {
+      throw new ValidationError('Course outcome, program outcome and weight are required.');
+    }
+
+    if (!this.findById('courseOutcomes', courseOutcomeId)) {
+      throw new ValidationError('Referenced course outcome does not exist.');
+    }
+
+    if (!this.findById('programOutcomes', programOutcomeId)) {
+      throw new ValidationError('Referenced program outcome does not exist.');
+    }
+
+    const composite = `${courseOutcomeId}|${programOutcomeId}`;
+    const exists = this.data.coPoMappings.some((mapping) => {
+      return `${mapping.courseOutcomeId}|${mapping.programOutcomeId}` === composite;
+    });
+
+    if (exists) {
+      throw new ValidationError('The CO and PO are already mapped.', 409);
+    }
+
+    const mapping = { id: generateId(), courseOutcomeId, programOutcomeId, weight };
+    this.data.coPoMappings.push(mapping);
+    await this.save();
+    return mapping;
+  }
+
+  async addAssessment(payload) {
+    const courseId = payload.courseId;
+    const name = (payload.name || '').trim();
+    const type = (payload.type || '').trim();
+    const maxMarks = Number(payload.maxMarks);
+    const semesterId = payload.semesterId;
+
+    if (!courseId || !name || !type || Number.isNaN(maxMarks) || !semesterId) {
+      throw new ValidationError('Assessment course, name, type, max marks and semester are required.');
+    }
+
+    if (!this.findById('courses', courseId)) {
+      throw new ValidationError('Referenced course does not exist.');
+    }
+
+    if (!this.findById('semesters', semesterId)) {
+      throw new ValidationError('Referenced semester does not exist.');
+    }
+
+    const assessment = { id: generateId(), courseId, name, type, maxMarks, semesterId };
+    this.data.assessments.push(assessment);
+    await this.save();
+    return assessment;
+  }
+
+  async addAssessmentCoMapping(payload) {
+    const assessmentId = payload.assessmentId;
+    const courseOutcomeId = payload.courseOutcomeId;
+    const weight = Number(payload.weight);
+
+    if (!assessmentId || !courseOutcomeId || Number.isNaN(weight)) {
+      throw new ValidationError('Assessment, course outcome and weight are required.');
+    }
+
+    if (!this.findById('assessments', assessmentId)) {
+      throw new ValidationError('Referenced assessment does not exist.');
+    }
+
+    if (!this.findById('courseOutcomes', courseOutcomeId)) {
+      throw new ValidationError('Referenced course outcome does not exist.');
+    }
+
+    const composite = `${assessmentId}|${courseOutcomeId}`;
+    const exists = this.data.assessmentCoMappings.some((mapping) => {
+      return `${mapping.assessmentId}|${mapping.courseOutcomeId}` === composite;
+    });
+
+    if (exists) {
+      throw new ValidationError('The assessment and course outcome are already mapped.', 409);
+    }
+
+    const mapping = { id: generateId(), assessmentId, courseOutcomeId, weight };
+    this.data.assessmentCoMappings.push(mapping);
+    await this.save();
+    return mapping;
+  }
+
+  async upsertMark(payload) {
+    const enrolmentId = payload.enrolmentId;
+    const assessmentId = payload.assessmentId;
+    const marks = Number(payload.marks);
+
+    if (!enrolmentId || !assessmentId || Number.isNaN(marks)) {
+      throw new ValidationError('Enrolment, assessment and marks are required.');
+    }
+
+    if (!this.findById('enrolments', enrolmentId)) {
+      throw new ValidationError('Referenced enrolment does not exist.');
+    }
+
+    if (!this.findById('assessments', assessmentId)) {
+      throw new ValidationError('Referenced assessment does not exist.');
+    }
+
+    let entry = this.data.marks.find(
+      (mark) => mark.enrolmentId === enrolmentId && mark.assessmentId === assessmentId
+    );
+    let created = false;
+
+    if (entry) {
+      entry.marks = marks;
+    } else {
+      entry = { id: generateId(), enrolmentId, assessmentId, marks };
+      this.data.marks.push(entry);
+      created = true;
+    }
+
+    await this.save();
+    return { entry, created };
+  }
+
+  async upsertCourseReport(payload) {
+    const courseId = payload.courseId;
+    const semesterId = payload.semesterId;
+    const year = (payload.year || '').trim();
+    const summary = (payload.summary || '').trim();
+    const actions = (payload.actions || '').trim();
+
+    if (!courseId || !semesterId || !year) {
+      throw new ValidationError('Course, semester and academic year are required.');
+    }
+
+    if (!this.findById('courses', courseId)) {
+      throw new ValidationError('Referenced course does not exist.');
+    }
+
+    if (!this.findById('semesters', semesterId)) {
+      throw new ValidationError('Referenced semester does not exist.');
+    }
+
+    const composite = `${courseId}|${semesterId}|${year}`;
+    let entry = this.data.courseReports.find((report) => {
+      return `${report.courseId}|${report.semesterId}|${report.year}` === composite;
+    });
+    let created = false;
+
+    if (entry) {
+      entry.summary = summary;
+      entry.actions = actions;
+    } else {
+      entry = { id: generateId(), courseId, semesterId, year, summary, actions };
+      this.data.courseReports.push(entry);
+      created = true;
+    }
+
+    await this.save();
+    return { entry, created };
+  }
+}
+
+function handleError(res, error) {
+  if (error instanceof ValidationError) {
+    res.status(error.status).json({ error: error.message });
+    return;
+  }
+  console.error('Unexpected error:', error);
+  res.status(500).json({ error: 'Internal server error' });
+}
+
+async function start() {
+  const store = new DataStore(DATA_FILE, initialData);
+  await store.init();
+
+  const app = express();
+  app.use(express.json());
+  app.use(express.static(path.join(__dirname)));
+
+  const collections = new Set(Object.keys(initialData));
+
+  app.get('/api/data', (req, res) => {
+    res.json(store.getAll());
+  });
+
+  app.get('/api/:collection', (req, res) => {
+    try {
+      const { collection } = req.params;
+      if (!collections.has(collection)) {
+        res.status(404).json({ error: 'Collection not found.' });
+        return;
+      }
+      res.json(store.list(collection));
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/programs', async (req, res) => {
+    try {
+      const program = await store.addProgram(req.body);
+      res.status(201).json(program);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/semesters', async (req, res) => {
+    try {
+      const semester = await store.addSemester(req.body);
+      res.status(201).json(semester);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/courses', async (req, res) => {
+    try {
+      const course = await store.addCourse(req.body);
+      res.status(201).json(course);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/students', async (req, res) => {
+    try {
+      const student = await store.addStudent(req.body);
+      res.status(201).json(student);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/enrolments', async (req, res) => {
+    try {
+      const enrolment = await store.addEnrolment(req.body);
+      res.status(201).json(enrolment);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/programOutcomes', async (req, res) => {
+    try {
+      const programOutcome = await store.addProgramOutcome(req.body);
+      res.status(201).json(programOutcome);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/courseOutcomes', async (req, res) => {
+    try {
+      const courseOutcome = await store.addCourseOutcome(req.body);
+      res.status(201).json(courseOutcome);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/coPoMappings', async (req, res) => {
+    try {
+      const mapping = await store.addCoPoMapping(req.body);
+      res.status(201).json(mapping);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/assessments', async (req, res) => {
+    try {
+      const assessment = await store.addAssessment(req.body);
+      res.status(201).json(assessment);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/assessmentCoMappings', async (req, res) => {
+    try {
+      const mapping = await store.addAssessmentCoMapping(req.body);
+      res.status(201).json(mapping);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/marks', async (req, res) => {
+    try {
+      const { entry, created } = await store.upsertMark(req.body);
+      res.status(created ? 201 : 200).json(entry);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.post('/api/courseReports', async (req, res) => {
+    try {
+      const { entry, created } = await store.upsertCourseReport(req.body);
+      res.status(created ? 201 : 200).json(entry);
+    } catch (error) {
+      handleError(res, error);
+    }
+  });
+
+  app.listen(PORT, () => {
+    console.log(`OBE portal server listening on http://localhost:${PORT}`);
+  });
+}
+
+start().catch((error) => {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,261 @@
+:root {
+    --bg: #f5f7fb;
+    --card-bg: #ffffff;
+    --primary: #2b66ff;
+    --primary-dark: #1b4fcc;
+    --text: #1b1f3b;
+    --muted: #4d5270;
+    --border: #d8dcee;
+    font-family: 'Inter', sans-serif;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: 'Inter', sans-serif;
+}
+
+.app-header {
+    background: linear-gradient(135deg, #2b66ff, #8b5cf6);
+    color: white;
+    padding: 2rem;
+    text-align: center;
+}
+
+.app-header h1 {
+    margin: 0;
+    font-size: 2.4rem;
+}
+
+.app-header .subtitle {
+    margin-top: 0.5rem;
+    opacity: 0.85;
+}
+
+.app-nav {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.5rem;
+    padding: 1rem;
+    background: white;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    border-bottom: 1px solid var(--border);
+}
+
+.app-nav button {
+    background: white;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.6rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--muted);
+    transition: all 0.2s ease;
+}
+
+.app-nav button:hover {
+    border-color: var(--primary);
+    color: var(--primary);
+}
+
+.app-nav button.active {
+    background: var(--primary);
+    color: white;
+    border-color: var(--primary);
+    box-shadow: 0 6px 16px rgba(43, 102, 255, 0.25);
+}
+
+main {
+    padding: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+section {
+    display: none;
+    margin-bottom: 3rem;
+}
+
+section.active {
+    display: block;
+}
+
+.section-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.card {
+    background: var(--card-bg);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 24px rgba(27, 31, 59, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+}
+
+.card h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.form-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.form-grid label {
+    display: grid;
+    gap: 0.4rem;
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+    padding: 0.65rem 0.75rem;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    font-size: 0.95rem;
+    font-family: 'Inter', sans-serif;
+}
+
+.form-grid button,
+.filter-grid button {
+    border: none;
+    border-radius: 10px;
+    padding: 0.75rem 1.25rem;
+    font-size: 1rem;
+    background: var(--primary);
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.form-grid button:hover,
+.filter-grid button:hover {
+    background: var(--primary-dark);
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+.data-table th,
+.data-table td {
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem;
+    text-align: left;
+    font-size: 0.95rem;
+}
+
+.data-table th {
+    background: #f3f4ff;
+    color: var(--muted);
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+}
+
+.data-table tbody tr:nth-child(even) {
+    background: #fafbff;
+}
+
+.filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    align-items: end;
+    margin-bottom: 1.5rem;
+}
+
+.filter-grid label {
+    display: grid;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--muted);
+}
+
+.filter-grid select,
+.filter-grid input {
+    padding: 0.6rem 0.75rem;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    font-size: 0.95rem;
+}
+
+.scrollable {
+    overflow-x: auto;
+}
+
+.report-table {
+    min-width: 480px;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.report-table th,
+.report-table td {
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem;
+}
+
+.report-table th {
+    background: #eef2ff;
+    text-align: left;
+}
+
+.intro {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.info-card {
+    background: white;
+    border-radius: 16px;
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    box-shadow: 0 10px 24px rgba(27, 31, 59, 0.08);
+}
+
+.empty-state {
+    color: var(--muted);
+    font-style: italic;
+    padding: 0.5rem 0;
+}
+
+.muted {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.app-footer {
+    text-align: center;
+    padding: 2rem 1rem 3rem;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+    main {
+        padding: 1rem;
+    }
+
+    .app-nav {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
+}


### PR DESCRIPTION
## Summary
- add an Express backend that serves the SPA, persists data to data.json, and exposes REST endpoints for all OBE entities
- switch the frontend data layer to use the backend API for creating and retrieving records instead of localStorage
- document the new backend workflow and dependencies in the README

## Testing
- npm install *(fails in the execution environment: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d16176d7b48326aa3b27b17d6a2f0d